### PR TITLE
refactor : Custom Exception 보안적 위반사례 검토

### DIFF
--- a/src/main/java/com/clean/cleanroom/exception/CustomException.java
+++ b/src/main/java/com/clean/cleanroom/exception/CustomException.java
@@ -2,15 +2,16 @@ package com.clean.cleanroom.exception;
 
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class CustomException extends RuntimeException {
 
-    private final ErrorMsg errorMsg;
+    private final HttpStatus httpStatus;
+    private final int code;
 
     public CustomException(ErrorMsg errorMsg) {
-        super(errorMsg.getDetails());
-        this.errorMsg = errorMsg;
+        this.httpStatus = errorMsg.getHttpStatus();
+        this.code = errorMsg.getCode();
     }
-
 }

--- a/src/main/java/com/clean/cleanroom/exception/ErrorMsg.java
+++ b/src/main/java/com/clean/cleanroom/exception/ErrorMsg.java
@@ -13,49 +13,51 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 public enum ErrorMsg {
 
     /* 400 BAD_REQUEST : 잘못된 요청 */
-    IMAGE_INVALID(BAD_REQUEST,"이미지가 잘못 되었습니다."),
-    PASSWORD_INCORRECT(BAD_REQUEST,"비밀번호가 옳지 않습니다."),
-    INVALID_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
-    MISSING_AUTHORIZATION_HEADER(BAD_REQUEST, "Authorization 헤더가 없거나 형식이 올바르지 않습니다."),
+    IMAGE_INVALID(HttpStatus.BAD_REQUEST, 1001, "이미지가 잘못되었습니다."),
+    PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, 1002, "비밀번호가 옳지 않습니다."),
+    MISSING_AUTHORIZATION_HEADER(HttpStatus.BAD_REQUEST, 1004, "Authorization 헤더가 없거나 형식이 올바르지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 1005, "잘못된 비밀번호 입니다."),
 
 
-    /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
-    UNAUTHORIZED_MEMBER(UNAUTHORIZED, "인증된 사용자가 아닙니다."),
-    NOT_LOGGED_ID(UNAUTHORIZED, "로그인이 되어있지 않습니다."),
-    EXPIRED_ACCESS_TOKEN(UNAUTHORIZED, "Access Token이 만료되었습니다. Refresh Token을 사용하여 재인증하세요."),
-    EXPIRED_REFRESH_TOKEN(UNAUTHORIZED, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."),
+    /* 401 UNAUTHORIZED : 인증되지 않음 */
+    UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, 2001, "인증되지 않은 사용자입니다."),
+    NOT_LOGGED_ID(HttpStatus.UNAUTHORIZED, 2002, "로그인이 되어있지 않습니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 2003, "Access Token이 만료되었습니다. Refresh Token을 사용하여 재인증하세요."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 2004, "Refresh Token이 만료되었습니다. 다시 로그인해주세요."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 2005, "유효하지 않은 토큰입니다."),
 
 
     /* 403 FORBIDDEN : 권한 없음 */
-    NOT_A_SELLER(FORBIDDEN, "판매자가 아닙니다"),
-    NOT_A_BUYER(FORBIDDEN, "구매자가 아닙니다"),
-    COMMISSION_NOT_FOUND_OR_UNAUTHORIZED(FORBIDDEN, "청소의뢰가 존재하지 않거나 권한이 없습니다."),
-
+    NOT_A_SELLER(HttpStatus.FORBIDDEN, 3001, "판매자가 아닙니다."),
+    NOT_A_BUYER(HttpStatus.FORBIDDEN, 3002, "구매자가 아닙니다."),
+    COMMISSION_NOT_FOUND_OR_UNAUTHORIZED(HttpStatus.FORBIDDEN, 3003, "청소의뢰가 존재하지 않거나 권한이 없습니다."),
 
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
-    MEMBER_NOT_FOUND(NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    REVIEW_NOT_FOUND(NOT_FOUND, "후기를 찾을 수 없습니다."),
-    COMMISSION_NOT_FOUND(NOT_FOUND, "청소의뢰를 찾을 수 없습니다."),
-    ADDRESS_NOT_FOUND(NOT_FOUND, "주소를 찾을 수 없습니다."),
-    ESTIMATE_NOT_FOUND(NOT_FOUND, "견적 내역을 찾을 수 없습니다."),
-    NO_ESTIMATES_FOUND(NOT_FOUND, "견적 내역이 존재하지 않습니다."),
-    PARTNER_NOT_FOUND(NOT_FOUND, "청소 업체를 찾을 수 없습니다."),
-    BUSINESS_INFO_NOT_FOUND(NOT_FOUND, "사업자 등록을 찾을 수 없습니다."),
-    ACCOUNT_NOT_FOUND(NOT_FOUND, "계좌번호를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, 4001, "사용자를 찾을 수 없습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, 4002, "후기를 찾을 수 없습니다."),
+    COMMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, 4003, "청소의뢰를 찾을 수 없습니다."),
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, 4004, "주소를 찾을 수 없습니다."),
+    ESTIMATE_NOT_FOUND(HttpStatus.NOT_FOUND, 4005, "견적 내역을 찾을 수 없습니다."),
+    NO_ESTIMATES_FOUND(HttpStatus.NOT_FOUND, 4006, "견적 내역이 존재하지 않습니다."),
+    PARTNER_NOT_FOUND(HttpStatus.NOT_FOUND, 4007, "청소 업체를 찾을 수 없습니다."),
+    BUSINESS_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, 4008, "사업자 등록을 찾을 수 없습니다."),
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 4009, "계좌번호를 찾을 수 없습니다."),
+    INVALID_ID(HttpStatus.NOT_FOUND, 4010, "존재하지 않는 아이디입니다."),
 
 
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
-    DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),
-    DUPLICATE_EMAIL(CONFLICT,"중복된 이메일입니다."),
+    DUPLICATE_USER(HttpStatus.CONFLICT, 5001, "이미 가입된 사용자입니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 5002, "중복된 이메일입니다."),
 
 
     /* 500 INTERNAL SERVER ERROR : 그 외 서버 에러 (컴파일 관련) */
-    FAILED_TO_EXECUTE_FILE(INTERNAL_SERVER_ERROR, "파일 실행에 실패했습니다."),
-    FAILED_TO_COMPILE_FILE(INTERNAL_SERVER_ERROR, "파일 컴파일에 실패했습니다.");
+    FAILED_TO_EXECUTE_FILE(HttpStatus.INTERNAL_SERVER_ERROR, 6001, "파일 실행에 실패했습니다."),
+    FAILED_TO_COMPILE_FILE(HttpStatus.INTERNAL_SERVER_ERROR, 6002, "파일 컴파일에 실패했습니다.");
 
 
     private final HttpStatus httpStatus;
+    private final int code;
     private final String details;
 }

--- a/src/main/java/com/clean/cleanroom/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clean/cleanroom/exception/GlobalExceptionHandler.java
@@ -22,31 +22,34 @@ public class GlobalExceptionHandler {
     // CustomException error
     @ExceptionHandler(value = {CustomException.class})
     protected ResponseEntity<ResponseDto> handleCustomException(CustomException e) {
-        log.error("handleCustomException throw CustomException : {}", e.getErrorMsg());
-        return ResponseDto.toExceptionResponseEntity(e.getErrorMsg());
+        log.error("handleCustomException throw CustomException : {}", e.getMessage());
+        return ResponseDto.toExceptionResponseEntity(e.getHttpStatus(), e.getCode());
     }
 
     // 정규식 error
     @ExceptionHandler({BindException.class})
-    public ResponseEntity<ResponseDto<?>> bindException(BindException e) {
-        return ResponseDto.toAllExceptionResponseEntity(HttpStatus.BAD_REQUEST,
-                e.getFieldError().getDefaultMessage());
+    public ResponseEntity<ResponseDto> bindException(BindException e) {
+        log.error("BindException occurred: ", e);
+        return ResponseDto.toExceptionResponseEntity(HttpStatus.BAD_REQUEST, 1000);
     }
 
     // 토큰 없을 시 error
     @ExceptionHandler({MissingRequestHeaderException.class})
-    public ResponseEntity<ResponseDto<?>> missingRequestHeaderException(MissingRequestHeaderException e) {
-        return ResponseDto.toAllExceptionResponseEntity(NOT_LOGGED_ID.getHttpStatus(), NOT_LOGGED_ID.getDetails());
+    public ResponseEntity<ResponseDto> missingRequestHeaderException(MissingRequestHeaderException e) {
+        log.error("MissingRequestHeaderException occurred: ", e);
+        return ResponseDto.toExceptionResponseEntity(HttpStatus.UNAUTHORIZED, 2000);
     }
 
     // 500 error
     @ExceptionHandler({Exception.class})
-    public ResponseEntity<ResponseDto<?>> handleAll(final Exception ex) {
-        return ResponseDto.toAllExceptionResponseEntity(HttpStatus.BAD_REQUEST, ex.getMessage());
+    public ResponseEntity<ResponseDto> handleAll(final Exception ex) {
+        log.error("Unexpected error occurred: ", ex);
+        return ResponseDto.toExceptionResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, 9999);
     }
 
     @ExceptionHandler(value = {IOException.class})
-    public ResponseEntity<ResponseDto<?>> handleIOException(IOException ex) {
-        return ResponseDto.toAllExceptionResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+    public ResponseEntity<ResponseDto> handleIOException(IOException ex) {
+        log.error("IOException occurred: ", ex);
+        return ResponseDto.toExceptionResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, 9998);
     }
 }

--- a/src/main/java/com/clean/cleanroom/members/controller/MembersLoginAndLogoutController.java
+++ b/src/main/java/com/clean/cleanroom/members/controller/MembersLoginAndLogoutController.java
@@ -18,12 +18,8 @@ public class MembersLoginAndLogoutController {
 
     @PostMapping("/login")
     public ResponseEntity<MembersLoginResponseDto> login(@RequestBody MembersLoginRequestDto requestDto) {
-        try {
-            return membersService.login(requestDto);
-        } catch (RuntimeException e) {
-            MembersLoginResponseDto errorResponse = new MembersLoginResponseDto(e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
-        }
+        return membersService.login(requestDto);
+
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/clean/cleanroom/members/service/MembersLoginService.java
+++ b/src/main/java/com/clean/cleanroom/members/service/MembersLoginService.java
@@ -1,5 +1,7 @@
 package com.clean.cleanroom.members.service;
 
+import com.clean.cleanroom.exception.CustomException;
+import com.clean.cleanroom.exception.ErrorMsg;
 import com.clean.cleanroom.members.dto.MembersLoginRequestDto;
 import com.clean.cleanroom.members.dto.MembersLoginResponseDto;
 import com.clean.cleanroom.members.dto.MembersLogoutResponseDto;
@@ -24,11 +26,11 @@ public class MembersLoginService {
     public ResponseEntity<MembersLoginResponseDto> login(MembersLoginRequestDto requestDto) {
         // 이메일로 회원을 조회. 없으면 예외를 던짐
         Members member = membersRepository.findByEmail(requestDto.getEmail())
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 아이디입니다."));
+                .orElseThrow(() -> new CustomException(ErrorMsg.INVALID_ID));
 
         // 비밀번호가 일치하는지 확인. 일치하지 않으면 예외를 던짐
         if (!member.checkPassword(requestDto.getPassword())) {
-            throw new RuntimeException("잘못된 비밀번호");
+            throw new CustomException(ErrorMsg.INVALID_PASSWORD);
         }
 
         // JWT 토큰 생성

--- a/src/main/java/com/clean/cleanroom/util/JwtUtil.java
+++ b/src/main/java/com/clean/cleanroom/util/JwtUtil.java
@@ -17,12 +17,14 @@ import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.security.Key;
 import java.util.Date;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {
@@ -71,8 +73,9 @@ public class JwtUtil {
                     .parseClaimsJws(token)
                     .getBody();
             return claims.getSubject();
-        } catch (SignatureException e) {
+        } catch (Exception e) {
             // 서명 예외 처리
+            log.error("Exception occurred while parsing token: {}", e.getMessage());
             throw new CustomException(ErrorMsg.INVALID_TOKEN);
         }
     }

--- a/src/main/java/com/clean/cleanroom/util/ResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/util/ResponseDto.java
@@ -14,35 +14,15 @@ import org.springframework.http.ResponseEntity;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ResponseDto<T> {
+public class ResponseDto {
     private int statusCode;
+    private int code;
 
-    @JsonInclude(JsonInclude.Include.NON_EMPTY) //@JsonInclude: 메시지가 null인 경우 출력을 안한다라는 뜻
-    private String message;
-
-    @JsonInclude(JsonInclude.Include.NON_EMPTY) //@JsonInclude: data가 null인 경우 출력을 안한다라는 뜻
-    private T data;
-
-
-    //ErrorMsg를 사용하여 응답을 생성
-    public static ResponseEntity<ResponseDto> toExceptionResponseEntity(ErrorMsg errorMsg) {
+    public static ResponseEntity<ResponseDto> toExceptionResponseEntity(HttpStatus httpStatus, int code) {
         return ResponseEntity
-                .status(errorMsg.getHttpStatus())
+                .status(httpStatus)
                 .body(ResponseDto.builder()
-                        .statusCode(errorMsg.getHttpStatus().value())
-                        .data(errorMsg.getDetails())
-                        .build()
-                );
-    }
-
-    //HTTP 상태 코드와 메시지를 사용하여 응답을 생성
-    public static ResponseEntity<ResponseDto<?>> toAllExceptionResponseEntity(HttpStatus httpStatus, String errorMsg) {
-        return ResponseEntity
-                .status(httpStatus.value())
-                .body(ResponseDto.builder()
-                        .statusCode(httpStatus.value())
-                        .message(errorMsg)
-                        .build()
-                );
+                        .code(code)
+                        .build());
     }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 예외 처리를 메시지가 아닌 코드로 교체
   - 현재 예외발생시 구체적인 이유를 클라이언트에게 메시지로 전달해줍니다.  이것은 공격자에게 시스템에 대한 중요한 정보를 제공할 수 있습니다. 
   - 따라서 오류코드 명세서를 작성하고 예외를 메시지가 아닌 코드로 교체했습니다.
- JWT 필터에 커스텀 익셉션이 적용되지 않던 오류를 해결했습니다.
- 로그인 로직에 커스텀 익셉션이 적용되지 않던 오류를 해결했습니다.


<br/>

## ⚡️ Issue number & Link
- #28 
- https://www.notion.so/675d2e26c584493997935449400fe8cd


## 📝 체크 리스트
- [x] 커스텀 익셥션 코드 명세서 작성
- [x] 커스텀 익셉션 핸들러 메시지가 아닌 코드로 교체하기
- [x] 필터의 `getEmailFromToken()` 메서드에 Custom Exception이 적용 되어 있지 않은 오류 수정
- [x] 로그인 메서드에 Custom Exception이 적용 되어 있지 않은 오류 수정

<br/>