### PR TITLE
refactor : 환경별로 로그 전략을 분리

### DIFF
--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,12 @@
+<included>
+
+    <!-- 어디에 기록할 것인가 (콘솔Appender) -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender"> <!-- 콘솔에 로그를 기록하는 Appender 설정 -->
+
+        <encoder> <!-- 어떻게 출력할 것인가 Encoder -->
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern> <!-- 인코딩할 패턴설정 -->
+        </encoder>
+
+    </appender>
+
+</included>

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,4 +1,4 @@
-<included>
+<included> <!-- 어떤 appender를 사용할지 추가 (자바에서 import와 동일) -->
 
     <!-- 어디에 기록할 것인가 (콘솔Appender) -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender"> <!-- 콘솔에 로그를 기록하는 Appender 설정 -->

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,0 +1,29 @@
+
+<included>
+
+    <!-- 에러 로그를 기록할 롤링 파일Appender: ERROR 레벨 로그만 기록 -->
+    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+        <!-- 로깅 필터설정 -->
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level> <!-- 필터링할 로그 레벨 설정 -->
+            <onMatch>ACCEPT</onMatch> <!-- 조건이 맞을 때 로그 기록 허용 -->
+            <onMismatch>DENY</onMismatch> <!-- 조건이 맞지 않을 때 로그 기록 거부 -->
+        </filter>
+
+        <!-- 어떻게 출력할 것인가 Encoder -->
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern> <!-- 파일에 기록할 패턴 설정 -->
+        </encoder>
+
+        <!-- 롤링 정책: 로그 파일을 일정 크기 또는 시간 단위로 롤링(분할) -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/pium-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern> <!-- 롤링된 파일 이름 패턴 설정 -->
+            <maxFileSize>50MB</maxFileSize> <!-- 최대 파일 크기 설정 -->
+            <maxHistory>30</maxHistory> <!-- 보관할 최대 파일 수 설정 -->
+            <totalSizeCap>3GB</totalSizeCap> <!-- 전체 로그 파일의 최대 크기 설정 -->
+        </rollingPolicy>
+
+    </appender>
+
+</included>

--- a/src/main/resources/file-error-appender.xml
+++ b/src/main/resources/file-error-appender.xml
@@ -1,5 +1,5 @@
 
-<included>
+<included> <!-- 어떤 appender를 사용할지 추가 (자바에서 import와 동일) -->
 
     <!-- 에러 로그를 기록할 롤링 파일Appender: ERROR 레벨 로그만 기록 -->
     <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,0 +1,21 @@
+<included>
+
+    <!-- 롤링 파일Appender: INFO 레벨 이상의 로그를 파일에 기록 -->
+    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender"> <!-- 파일에 로그를 기록하는 Appender 설정 -->
+
+        <!-- 어떻게 출력할 것인가 Encoder -->
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern> <!-- 인코딩할 패턴설정 -->
+        </encoder>
+
+        <!-- 롤링 정책: 로그 파일을 일정 크기 또는 시간 단위로 롤링(분할) -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./log/pium-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern> <!-- 롤링된 파일 이름 패턴 설정 -->
+            <maxFileSize>50MB</maxFileSize> <!-- 최대 파일 크기 설정 -->
+            <maxHistory>30</maxHistory> <!-- 보관할 최대 파일 수 설정 -->
+            <totalSizeCap>1GB</totalSizeCap> <!-- 전체 로그 파일의 최대 크기 설정 -->
+        </rollingPolicy>
+
+    </appender>
+
+</included>

--- a/src/main/resources/file-info-appender.xml
+++ b/src/main/resources/file-info-appender.xml
@@ -1,4 +1,4 @@
-<included>
+<included> <!-- 어떤 appender를 사용할지 추가 (자바에서 import와 동일) -->
 
     <!-- 롤링 파일Appender: INFO 레벨 이상의 로그를 파일에 기록 -->
     <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender"> <!-- 파일에 로그를 기록하는 Appender 설정 -->

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -13,55 +13,6 @@
 
 
 
-    <!-- 어디에 기록할 것인가 (콘솔Appender) -->
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender"> <!-- 콘솔에 로그를 기록하는 Appender 설정 -->
-        <encoder> <!-- 어떻게 출력할 것인가 Encoder -->
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern> <!-- 인코딩할 패턴설정 -->
-        </encoder>
-    </appender>
-
-
-    <!-- 롤링 파일Appender: INFO 레벨 이상의 로그를 파일에 기록 -->
-    <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender"> <!-- 파일에 로그를 기록하는 Appender 설정 -->
-
-        <!-- 어떻게 출력할 것인가 Encoder -->
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern> <!-- 인코딩할 패턴설정 -->
-        </encoder>
-
-        <!-- 롤링 정책: 로그 파일을 일정 크기 또는 시간 단위로 롤링(분할) -->
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/pium-info-%d{yyyy-MM-dd}.%i.log</fileNamePattern> <!-- 롤링된 파일 이름 패턴 설정 -->
-            <maxFileSize>50MB</maxFileSize> <!-- 최대 파일 크기 설정 -->
-            <maxHistory>30</maxHistory> <!-- 보관할 최대 파일 수 설정 -->
-            <totalSizeCap>1GB</totalSizeCap> <!-- 전체 로그 파일의 최대 크기 설정 -->
-        </rollingPolicy>
-    </appender>
-
-    <!-- 에러 로그를 기록할 롤링 파일Appender: ERROR 레벨 로그만 기록 -->
-    <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>ERROR</level> <!-- 필터링할 로그 레벨 설정 -->
-            <onMatch>ACCEPT</onMatch> <!-- 조건이 맞을 때 로그 기록 허용 -->
-            <onMismatch>DENY</onMismatch> <!-- 조건이 맞지 않을 때 로그 기록 거부 -->
-        </filter>
-
-        <!-- 어떻게 출력할 것인가 Encoder -->
-        <encoder>
-            <pattern>${FILE_LOG_PATTERN}</pattern> <!-- 파일에 기록할 패턴 설정 -->
-        </encoder>
-
-        <!-- 롤링 정책: 로그 파일을 일정 크기 또는 시간 단위로 롤링(분할) -->
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>./log/pium-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern> <!-- 롤링된 파일 이름 패턴 설정 -->
-            <maxFileSize>50MB</maxFileSize> <!-- 최대 파일 크기 설정 -->
-            <maxHistory>30</maxHistory> <!-- 보관할 최대 파일 수 설정 -->
-            <totalSizeCap>3GB</totalSizeCap> <!-- 전체 로그 파일의 최대 크기 설정 -->
-        </rollingPolicy>
-    </appender>
-
-
-
     <!-- 루트로거: 최상위 로거 설정 (INFO 레벨 이상의 로그를 콘솔에 기록)-->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/> <!-- 콘솔 Appender를 root logger에 연결 -->

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -13,13 +13,58 @@
 
 
 
-    <!-- 루트로거: 최상위 로거 설정 (INFO 레벨 이상의 로그를 콘솔에 기록)-->
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/> <!-- 콘솔 Appender를 root logger에 연결 -->
-        <appender-ref ref="FILE-INFO"/> <!-- 파일-INFO Appender를 root logger에 연결 -->
-        <appender-ref ref="FILE-ERROR"/> <!-- 파일-ERROR Appender를 root logger에 연결 -->
-    </root>
+    <!--local 환경에서의 로그설정-->
+    <springProfile name="local">
 
+        <!-- include = 어떤 appender를 사용할지 추가 (자바 import와 동일)  -->
+        <include resource="console-appender.xml"/>
+
+        <!-- 루트 로거 설정: INFO 레벨 이상의 로그를 콘솔에 기록 -->
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/> <!-- 필요한 appender 이름을 appender-ref 태그에 추가 -->
+        </root>
+
+    </springProfile>
+
+
+    <!--develop 환경에서의 로그설정-->
+    <springProfile name="develop">
+
+        <!-- include = 어떤 appender를 사용할지 추가 (자바 import와 동일)  -->
+        <include resource="file-error-appender.xml"/>
+
+        <!-- 루트 로거 설정: ERROR 레벨의 로그를 파일에 기록 -->
+        <root level="ERROR">
+            <appender-ref ref="FILE-ERROR"/> <!-- 필요한 appender 이름을 appender-ref 태그에 추가 -->
+        </root>
+
+    </springProfile>
+
+    <!--blue 환경에서의 로그설정-->
+    <springProfile name="blue">
+
+        <!-- include = 어떤 appender를 사용할지 추가 (자바 import와 동일)  -->
+        <include resource="file-error-appender.xml"/>
+
+        <!-- 루트 로거 설정: ERROR 레벨의 로그를 파일에 기록 -->
+        <root level="ERROR">
+            <appender-ref ref="FILE-ERROR"/> <!-- 필요한 appender 이름을 appender-ref 태그에 추가 -->
+        </root>
+
+    </springProfile>
+
+    <!--green 환경에서의 로그설정-->
+    <springProfile name="green">
+
+        <!-- include = 어떤 appender를 사용할지 추가 (자바 import와 동일)  -->
+        <include resource="file-error-appender.xml"/>
+
+        <!-- 루트 로거 설정: ERROR 레벨의 로그를 파일에 기록 -->
+        <root level="ERROR">
+            <appender-ref ref="FILE-ERROR"/> <!-- 필요한 appender 이름을 appender-ref 태그에 추가 -->
+        </root>
+
+    </springProfile>
 
 
 </configuration>


### PR DESCRIPTION
## 🛠️ 작업 내용
- console, file-info, file-error appender 들을 각각의 xml 파일로 분리하였습니다.
- 각각의 환경별로 로그 전략을 분리하였습니다.
  - local 환경에서는 `INFO` 레벨 이상의 로그들이 작성되도록 전략을 분리하였습니다.
  - 그 외의 환경에서는 `ERROR` 레벨 이상의 로그들이 작성되도록 전략을 분리하였습니다.

<br/>

## ⚡️ Issue number & Link
- #34 

<br/>

## 📝 체크 리스트
- [x] local 환경에서는 `INFO` 레벨 이상의 로그들이 작성되도록 분리
- [x] 그 외의 환경에서는 `ERROR` 레벨 이상의 로그들이 작성되도록 분리
- [x]  console, file-info, file-error appender 들을 각각의 xml 파일로 분리

<br/>
