### PR TITLE
Fix : commission 청소의뢰가 삭제될때 연관된 청소견적들이 사라지도록 종속성 전이 수정

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/entity/Commission.java
+++ b/src/main/java/com/clean/cleanroom/commission/entity/Commission.java
@@ -4,6 +4,7 @@ import com.clean.cleanroom.commission.dto.CommissionCreateRequestDto;
 import com.clean.cleanroom.commission.dto.CommissionUpdateRequestDto;
 import com.clean.cleanroom.enums.CleanType;
 import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.estimate.entity.Estimate;
 import com.clean.cleanroom.members.entity.Address;
 import com.clean.cleanroom.members.entity.Members;
 import jakarta.persistence.*;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Entity
@@ -30,6 +32,9 @@ public class Commission {
     @ManyToOne
     @JoinColumn(name = "address_id")
     private Address address;
+
+    @OneToMany(mappedBy = "commission", cascade = CascadeType.REMOVE)
+    private List<Estimate> estimates;
 
     @Column(nullable = false, length = 255)
     @Comment("이미지")

--- a/src/main/java/com/clean/cleanroom/estimate/dto/EstimateListResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/estimate/dto/EstimateListResponseDto.java
@@ -22,7 +22,7 @@ public class EstimateListResponseDto {
 
     public  EstimateListResponseDto(Estimate estimate) {
         this.id = estimate.getId();
-        this.commissionId = estimate.getCommissionId().getId();
+        this.commissionId = estimate.getCommission().getId();
         this.fixedDate = estimate.getFixedDate();
         this.price = estimate.getPrice();
         this.statement = estimate.getStatement();

--- a/src/main/java/com/clean/cleanroom/estimate/entity/Estimate.java
+++ b/src/main/java/com/clean/cleanroom/estimate/entity/Estimate.java
@@ -20,11 +20,11 @@ public class Estimate {
 
     @ManyToOne
     @JoinColumn(name = "commission_id")
-    private Commission commissionId;
+    private Commission commission;
 
     @ManyToOne
     @JoinColumn(name = "partner_id")
-    private Partner partnerId;
+    private Partner partner;
 
     @Column(nullable = false)
     @Comment("가격")

--- a/src/main/java/com/clean/cleanroom/estimate/service/EstimateService.java
+++ b/src/main/java/com/clean/cleanroom/estimate/service/EstimateService.java
@@ -47,7 +47,7 @@ public class EstimateService {
         Estimate estimate = estimateRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorMsg.ESTIMATE_NOT_FOUND));
 
-        Commission commission = estimate.getCommissionId();// 견적에 연결된 Commission 가져오기
+        Commission commission = estimate.getCommission();// 견적에 연결된 Commission 가져오기
 
         Members owner = commission.getMembers(); // Commission에 연결된 회원 가져오기
 


### PR DESCRIPTION
## 🛠️ 작업 내용
-  청소의뢰가 삭제될때 연관된 청소견적들이 사라지도록 종속성 전이를 추가하였습니다.

<br/>

## ⚡️ Issue number & Link
- #55

<br/>

## 📝 체크 리스트
- [x] 청소 의뢰에 연관관계 설정하기
- [x] 종속성 전이 수정하기

<br/>