### PR TITLE
feat : 견적을 받은 청소 의뢰 리스트 조회

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
+++ b/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
@@ -65,6 +65,14 @@ public class CommissionController {
         return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
     }
 
+    // 견적을 받은 청소 의뢰 리스트 조회
+    @GetMapping("/confirmed")
+    public ResponseEntity<List<CommissionConfirmListResponseDto>> getConfirmedCommissions(HttpServletRequest request) {
+        String email = tokenService.getEmailFromRequest(request); // 헤더의 토큰에서 이메일 추출
+
+        List<CommissionConfirmListResponseDto> responseDtoList = commissionService.getCommissionConfirmList(email);
+        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
+    }
 
 }
 

--- a/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
+++ b/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
@@ -35,7 +35,7 @@ public class CommissionController {
 
 
     //청소의뢰 수정
-    @PutMapping
+    @PatchMapping
     public ResponseEntity<List<CommissionUpdateResponseDto>> updateCommission(
             HttpServletRequest request,
             @RequestParam Long commissionId,

--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
@@ -1,0 +1,39 @@
+package com.clean.cleanroom.commission.dto;
+
+import com.clean.cleanroom.commission.entity.Commission;
+import com.clean.cleanroom.enums.CleanType;
+import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.estimate.dto.EstimateResponseDto;
+import com.clean.cleanroom.estimate.entity.Estimate;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CommissionConfirmListResponseDto {
+
+    private Long id;
+    private int size;
+    private HouseType houseType;
+    private CleanType cleanType;
+    private LocalDateTime desiredDate;
+    private String significant;
+
+    private List<EstimateResponseDto> estimates;
+
+
+    // 생성자 추가
+    public CommissionConfirmListResponseDto(Long id, int size, HouseType houseType, CleanType cleanType,
+                                            LocalDateTime desiredDate, String significant,
+                                            List<EstimateResponseDto> estimates) {
+        this.id = id;
+        this.size = size;
+        this.houseType = houseType;
+        this.cleanType = cleanType;
+        this.desiredDate = desiredDate;
+        this.significant = significant;
+        this.estimates = estimates;
+    }
+}

--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionUpdateRequestDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionUpdateRequestDto.java
@@ -2,6 +2,7 @@ package com.clean.cleanroom.commission.dto;
 
 import com.clean.cleanroom.enums.CleanType;
 import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.enums.StatusType;
 import lombok.Getter;
 import java.time.LocalDateTime;
 
@@ -14,9 +15,10 @@ public class CommissionUpdateRequestDto {
     private CleanType cleanType;
     private LocalDateTime desiredDate;
     private String significant;
+    private StatusType status;
 
 
-    public CommissionUpdateRequestDto(String image, int size, HouseType houseType, CleanType cleanType, LocalDateTime desiredDate, String significant) {
+    public CommissionUpdateRequestDto(String image, int size, HouseType houseType, CleanType cleanType, LocalDateTime desiredDate, String significant, StatusType status) {
 
         this.image = image;
         this.size = size;
@@ -24,6 +26,7 @@ public class CommissionUpdateRequestDto {
         this.cleanType = cleanType;
         this.desiredDate = desiredDate;
         this.significant = significant;
+        this.status = status;
     }
 
 }

--- a/src/main/java/com/clean/cleanroom/commission/entity/Commission.java
+++ b/src/main/java/com/clean/cleanroom/commission/entity/Commission.java
@@ -4,6 +4,7 @@ import com.clean.cleanroom.commission.dto.CommissionCreateRequestDto;
 import com.clean.cleanroom.commission.dto.CommissionUpdateRequestDto;
 import com.clean.cleanroom.enums.CleanType;
 import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.enums.StatusType;
 import com.clean.cleanroom.estimate.entity.Estimate;
 import com.clean.cleanroom.members.entity.Address;
 import com.clean.cleanroom.members.entity.Members;
@@ -55,6 +56,11 @@ public class Commission {
     private CleanType cleanType;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Comment("의뢰 상태")
+    private StatusType status;
+
+    @Column(nullable = false)
     @Comment("희망 날짜")
     private LocalDateTime desiredDate;
 
@@ -63,7 +69,7 @@ public class Commission {
     private String significant;
 
 
-    public Commission(Members members, Address address,CommissionCreateRequestDto requestDto) {
+    public Commission(Members members, Address address, CommissionCreateRequestDto requestDto) {
         this.members = members;
         this.address = address;
         this.image = requestDto.getImage();
@@ -72,6 +78,7 @@ public class Commission {
         this.cleanType = requestDto.getCleanType();
         this.desiredDate = requestDto.getDesiredDate();
         this.significant = requestDto.getSignificant();
+        this.status = StatusType.CHECK;
     }
 
     public void update(CommissionUpdateRequestDto requestDto, Address address) {
@@ -82,5 +89,6 @@ public class Commission {
         this.cleanType = requestDto.getCleanType();
         this.desiredDate = requestDto.getDesiredDate();
         this.significant = requestDto.getSignificant();
+        this.status = requestDto.getStatus();
     }
 }

--- a/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
+++ b/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
@@ -1,6 +1,7 @@
 package com.clean.cleanroom.commission.repository;
 
 import com.clean.cleanroom.commission.entity.Commission;
+import com.clean.cleanroom.members.entity.Members;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,4 +12,7 @@ public interface CommissionRepository extends JpaRepository<Commission, Long> {
     Optional<List<Commission>> findByMembersId(Long membersId);
 
     Optional<Commission> findByIdAndMembersId(Long id, Long membersId);
+
+    List<Commission> findByMembers(Members members);
+
 }

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -3,6 +3,8 @@ package com.clean.cleanroom.commission.service;
 import com.clean.cleanroom.commission.dto.*;
 import com.clean.cleanroom.commission.entity.Commission;
 import com.clean.cleanroom.commission.repository.CommissionRepository;
+import com.clean.cleanroom.estimate.dto.EstimateResponseDto;
+import com.clean.cleanroom.estimate.entity.Estimate;
 import com.clean.cleanroom.exception.CustomException;
 import com.clean.cleanroom.exception.ErrorMsg;
 import com.clean.cleanroom.members.entity.Address;
@@ -84,6 +86,27 @@ public class CommissionService {
         return getMemberCommissionsByEmail(email, CommissionCancelResponseDto.class);
     }
 
+    //견적이 있는 청소의뢰 리스트 조회
+    public List<CommissionConfirmListResponseDto> getCommissionConfirmList(String email) {
+        Members members = getMemberByEmail(email);
+
+        List<Commission> commissions = commissionRepository.findByMembers(members);
+
+        // 견적이 있는 청소 의뢰 필터링 및 모든 견적 추가
+        List<CommissionConfirmListResponseDto> responseList = new ArrayList<>();
+        for (Commission commission : commissions) {
+            for (Estimate estimate : commission.getEstimates()) {
+                CommissionConfirmListResponseDto dto = convertToConfirmListDto(commission, estimate); // dto 변환
+                responseList.add(dto); // 변환된 dto를 리스트에 추가
+            }
+        }
+        return responseList;
+
+    }
+
+
+
+
     // 특정 회원(나) 청소의뢰 내역 전체조회
     public <T> List<T> getMemberCommissionsByEmail(String email, Class<T> responseType) {
 
@@ -149,4 +172,22 @@ public class CommissionService {
         }
         return responseDtoList;
     }
+
+
+    // Commission과 Estimate를 받아서 CommissionConfirmListResponseDto로 변환하는 메서드
+    private CommissionConfirmListResponseDto convertToConfirmListDto(Commission commission, Estimate estimate) {
+        List<EstimateResponseDto> estimateResponseDtos = new ArrayList<>();
+        estimateResponseDtos.add(new EstimateResponseDto(estimate));
+
+        return new CommissionConfirmListResponseDto(
+                commission.getId(),
+                commission.getSize(),
+                commission.getHouseType(),
+                commission.getCleanType(),
+                commission.getDesiredDate(),
+                commission.getSignificant(),
+                estimateResponseDtos
+        );
+    }
+
 }

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -84,7 +84,6 @@ public class CommissionService {
         return getMemberCommissionsByEmail(email, CommissionCancelResponseDto.class);
     }
 
-
     // 특정 회원(나) 청소의뢰 내역 전체조회
     public <T> List<T> getMemberCommissionsByEmail(String email, Class<T> responseType) {
 

--- a/src/main/java/com/clean/cleanroom/enums/PartnerType.java
+++ b/src/main/java/com/clean/cleanroom/enums/PartnerType.java
@@ -1,0 +1,7 @@
+package com.clean.cleanroom.enums;
+
+public enum PartnerType {
+    INDIVIDUAL, //개인사업자
+    CORPORATION, //법인사업자
+    PUBLIC_INSTITUTION //공공기관
+}

--- a/src/main/java/com/clean/cleanroom/enums/StatusType.java
+++ b/src/main/java/com/clean/cleanroom/enums/StatusType.java
@@ -1,0 +1,9 @@
+package com.clean.cleanroom.enums;
+
+public enum StatusType {
+
+    CHECK,
+    SEND,
+    FINISH
+
+}

--- a/src/main/java/com/clean/cleanroom/estimate/dto/EstimateResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/estimate/dto/EstimateResponseDto.java
@@ -4,16 +4,31 @@ import com.clean.cleanroom.estimate.entity.Estimate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class EstimateResponseDto {
 
-    private boolean approve;
-    private String message;
+
+    private Long id;
+    private int price;
+    private LocalDateTime fixedDate;
+    private String statement;
+    private boolean approved;
+
+    // 필요한 추가 정보들
+    private Long partnerId;
+    private String partnerName;
 
     public EstimateResponseDto(Estimate estimate) {
-        this.approve = true;
-        this.message = "견적이 승인 되었습니다.";
+        this.id = estimate.getId();
+        this.price = estimate.getPrice();
+        this.fixedDate = estimate.getFixedDate();
+        this.statement = estimate.getStatement();
+        this.approved = estimate.isApproved();
+        this.partnerId = estimate.getPartner().getId();
+        this.partnerName = estimate.getPartner().getCompanyName();
     }
 }
 

--- a/src/main/java/com/clean/cleanroom/partner/entity/Partner.java
+++ b/src/main/java/com/clean/cleanroom/partner/entity/Partner.java
@@ -1,19 +1,41 @@
 package com.clean.cleanroom.partner.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import com.clean.cleanroom.enums.PartnerType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
 @Entity
 @Getter
+@NoArgsConstructor
 public class Partner {
-
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 25, unique = true)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @Column(nullable = false, length = 15, unique = true)
     private String phoneNumber;
+
+    @Column(nullable = false, length = 15)
+    private String managerName;
+
+    @Column(nullable = false, length = 100)
+    private String companyName;
+
+    @Column(nullable = false, length = 15)
+    private String businessType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PartnerType partnerType;
+
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 청소 의뢰 생성과 수정에 상태 enum을 추가하였습니다.
- 청소의뢰 수정 컨트롤러를 부분 수정이 가능하도록 PUT 에서 PATCH로 변경하였습니다.
- 견적을 받은 청소의뢰 리스트를 조회할 수 있습니다.
 또한 청소내용에 연결된 견적내용이 함께 나오도록 하였습니다.

<br/>

## ⚡️ Issue number & Link

<br/>

## 📝 체크 리스트
- [x] 청소의뢰 생성, 수정에 상태이넘 추가
- [x] 수정 컨트롤러 PUT에서 PATCH 매핑으로 변경
- [x] 견적을 받은 청소 의뢰 리스트 조회

<br/>
