### PR TITLE
Refactor : commission Status추가

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
@@ -3,6 +3,7 @@ package com.clean.cleanroom.commission.dto;
 import com.clean.cleanroom.commission.entity.Commission;
 import com.clean.cleanroom.enums.CleanType;
 import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.enums.StatusType;
 import com.clean.cleanroom.estimate.dto.EstimateResponseDto;
 import com.clean.cleanroom.estimate.entity.Estimate;
 import lombok.Getter;
@@ -21,13 +22,14 @@ public class CommissionConfirmListResponseDto {
     private LocalDateTime desiredDate;
     private String significant;
     private String image;
+    private StatusType statusType;
 
     private List<EstimateResponseDto> estimates;
 
 
     // 생성자 추가
     public CommissionConfirmListResponseDto(Long id, int size, HouseType houseType, CleanType cleanType,
-                                            LocalDateTime desiredDate, String significant, String image,
+                                            LocalDateTime desiredDate, String significant, String image, StatusType statusType,
                                             List<EstimateResponseDto> estimates) {
         this.id = id;
         this.size = size;
@@ -37,5 +39,6 @@ public class CommissionConfirmListResponseDto {
         this.significant = significant;
         this.image = image;
         this.estimates = estimates;
+        this.statusType = statusType;
     }
 }

--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionUpdateResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionUpdateResponseDto.java
@@ -3,6 +3,7 @@ package com.clean.cleanroom.commission.dto;
 import com.clean.cleanroom.commission.entity.Commission;
 import com.clean.cleanroom.enums.CleanType;
 import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.enums.StatusType;
 import lombok.Getter;
 import java.time.LocalDateTime;
 
@@ -17,6 +18,7 @@ public class CommissionUpdateResponseDto {
     private Long addressId;
     private LocalDateTime desiredDate;
     private String significant;
+    private StatusType statusType;
 
 
 
@@ -29,6 +31,7 @@ public class CommissionUpdateResponseDto {
         this.addressId = commission.getAddress().getId();
         this.desiredDate = commission.getDesiredDate();
         this.significant = commission.getSignificant();
+        this.statusType = commission.getStatus();
     }
 
 }

--- a/src/main/java/com/clean/cleanroom/commission/dto/MyCommissionResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/MyCommissionResponseDto.java
@@ -3,6 +3,7 @@ package com.clean.cleanroom.commission.dto;
 import com.clean.cleanroom.commission.entity.Commission;
 import com.clean.cleanroom.enums.CleanType;
 import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.enums.StatusType;
 import lombok.Getter;
 import java.time.LocalDateTime;
 
@@ -18,6 +19,7 @@ public class MyCommissionResponseDto {
     private LocalDateTime desiredDate;
     private String significant;
     private String image;
+    private StatusType statusType;
 
 
     public MyCommissionResponseDto(Commission commission) {
@@ -30,6 +32,7 @@ public class MyCommissionResponseDto {
         this.desiredDate = commission.getDesiredDate();
         this.significant = commission.getSignificant();
         this.image = commission.getImage();
+        this.statusType = commission.getStatus();
     }
 
 }

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -188,6 +188,7 @@ public class CommissionService {
                 commission.getDesiredDate(),
                 commission.getSignificant(),
                 commission.getImage(),
+                commission.getStatus(),
                 estimateResponseDtos
         );
     }

--- a/src/main/java/com/clean/cleanroom/estimate/dto/EstimateResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/estimate/dto/EstimateResponseDto.java
@@ -1,5 +1,6 @@
 package com.clean.cleanroom.estimate.dto;
 
+import com.clean.cleanroom.enums.StatusType;
 import com.clean.cleanroom.estimate.entity.Estimate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ public class EstimateResponseDto {
     private LocalDateTime fixedDate;
     private String statement;
     private boolean approved;
+    private StatusType statusType;
 
     // 필요한 추가 정보들
     private Long partnerId;
@@ -29,6 +31,7 @@ public class EstimateResponseDto {
         this.approved = estimate.isApproved();
         this.partnerId = estimate.getPartner().getId();
         this.partnerName = estimate.getPartner().getCompanyName();
+        this.statusType = estimate.getStatus();
     }
 }
 


### PR DESCRIPTION
## 🛠️ 작업 내용
- 현재 청소의뢰 관련 로직들은 응답시 Status를 반환하지 않습니다. 
프론트엔드의 요청사항에 따라 응답 시 Status를 반환하도록 수정하였습니다.

<br/>

## ⚡️ Issue number & Link
<br/>

## 📝 체크 리스트
- [x] 견적 작성된 청소의뢰 전체 조회시 Status로 나타나도록 수정
- [x] 청소의뢰 수정 API 동작시 Status가 나타나도록 수정
- [x] 내 청소의뢰내역 조회 API 동작시 Status가 나타나도록 수정

<br/>
