### PR TITLE
Refactor : commission 청소의뢰 단건조회 API 수정

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
+++ b/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
@@ -2,8 +2,6 @@ package com.clean.cleanroom.commission.controller;
 
 import com.clean.cleanroom.commission.dto.*;
 import com.clean.cleanroom.commission.service.CommissionService;
-import com.clean.cleanroom.members.dto.MembersAddressRequestDto;
-import com.clean.cleanroom.members.dto.MembersAddressResponseDto;
 import com.clean.cleanroom.util.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
@@ -71,13 +69,13 @@ public class CommissionController {
         return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
     }
 
-    // 견적을 받은 청소 의뢰 리스트 조회
+    //청소견적이 리스트로 붙어있는 청소의뢰 단건조회
     @GetMapping("/confirmed")
-    public ResponseEntity<List<CommissionConfirmListResponseDto>> getConfirmedCommissions(HttpServletRequest request) {
+    public ResponseEntity<CommissionConfirmListResponseDto> getConfirmedCommissions(HttpServletRequest request, @RequestParam Long commissionId) {
         String email = tokenService.getEmailFromRequest(request); // 헤더의 토큰에서 이메일 추출
 
-        List<CommissionConfirmListResponseDto> responseDtoList = commissionService.getCommissionConfirmList(email);
-        return new ResponseEntity<>(responseDtoList, HttpStatus.OK);
+        CommissionConfirmListResponseDto responseDto = commissionService.getCommissionConfirmList(email, commissionId);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
+++ b/src/main/java/com/clean/cleanroom/commission/controller/CommissionController.java
@@ -81,9 +81,12 @@ public class CommissionController {
     }
 
 
+    //청소의뢰 단건조회
     @GetMapping("/confirmdetail")
-    public ResponseEntity<CommissionConfirmDetailResponseDto> getConfirmDetailCommissions(@RequestParam Long estimateId, Long commissionId) {
-        CommissionConfirmDetailResponseDto responseDto = commissionService.getCommissionDetailConfirm(estimateId, commissionId);
+    public ResponseEntity<CommissionConfirmDetailResponseDto> getConfirmDetailCommissions(HttpServletRequest request, @RequestParam Long commissionId) {
+        String email = tokenService.getEmailFromRequest(request); //헤더의 토큰에서 이메일 추출
+
+        CommissionConfirmDetailResponseDto responseDto = commissionService.getCommissionDetailConfirm(email, commissionId);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 

--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmDetailResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmDetailResponseDto.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 public class CommissionConfirmDetailResponseDto {
     private Long commissionId;
+    private String memberNick;
     private int size;
     private HouseType houseType;
     private CleanType cleanType;
@@ -20,29 +21,17 @@ public class CommissionConfirmDetailResponseDto {
     private LocalDateTime desiredDate;
     private String significant;
     private StatusType status;
-    private StatusType estimatedStatus;
-    private int tmpPrice;
-    private int Price;
-    private String statment;
-    private LocalDateTime fixedDate;
-    private String image;
 
 
-
-    public CommissionConfirmDetailResponseDto(Commission commission, Estimate estimate, Address address) {
+    public CommissionConfirmDetailResponseDto(Commission commission) {
         this.commissionId = commission.getId();
+        this.memberNick = commission.getMembers().getNick();
         this.size = commission.getSize();
         this.houseType = commission.getHouseType();
         this.cleanType = commission.getCleanType();
-        this.addressId = address.getId();
-        this.desiredDate = getDesiredDate();
-        this.significant = getSignificant();
-        this.status = getStatus();
-        this.estimatedStatus = estimate.getStatus();
-        this.tmpPrice = estimate.getTmpPrice();
-        this.Price = estimate.getPrice();
-        this.statment = estimate.getStatement();
-        this.fixedDate = estimate.getFixedDate();
-        this.image = commission.getImage();
+        this.addressId = commission.getAddress().getId();
+        this.desiredDate = commission.getDesiredDate();
+        this.significant = commission.getSignificant();
+        this.status = commission.getStatus();
     }
 }

--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmDetailResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmDetailResponseDto.java
@@ -21,6 +21,7 @@ public class CommissionConfirmDetailResponseDto {
     private LocalDateTime desiredDate;
     private String significant;
     private StatusType status;
+    private String image;
 
 
     public CommissionConfirmDetailResponseDto(Commission commission) {
@@ -33,5 +34,6 @@ public class CommissionConfirmDetailResponseDto {
         this.desiredDate = commission.getDesiredDate();
         this.significant = commission.getSignificant();
         this.status = commission.getStatus();
+        this.image = commission.getImage();
     }
 }

--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
@@ -27,18 +27,17 @@ public class CommissionConfirmListResponseDto {
     private List<EstimateResponseDto> estimates;
 
 
-    // 생성자 추가
-    public CommissionConfirmListResponseDto(Long id, int size, HouseType houseType, CleanType cleanType,
-                                            LocalDateTime desiredDate, String significant, String image, StatusType status,
-                                            List<EstimateResponseDto> estimates) {
-        this.id = id;
-        this.size = size;
-        this.houseType = houseType;
-        this.cleanType = cleanType;
-        this.desiredDate = desiredDate;
-        this.significant = significant;
-        this.image = image;
-        this.estimates = estimates;
-        this.status = status;
+
+
+    public CommissionConfirmListResponseDto(Commission commission, List<EstimateResponseDto> estimateDtos) {
+        this.id = commission.getId();
+        this.size = commission.getSize();
+        this.houseType = commission.getHouseType();
+        this.cleanType = commission.getCleanType();
+        this.desiredDate = commission.getDesiredDate();
+        this.significant = commission.getSignificant();
+        this.image = commission.getImage();
+        this.status = commission.getStatus();
+        this.estimates = estimateDtos;
     }
 }

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -97,25 +97,6 @@ public class CommissionService {
         return getMemberCommissionsByEmail(email, CommissionCancelResponseDto.class);
     }
 
-    //견적이 있는 청소의뢰 리스트 조회
-    public List<CommissionConfirmListResponseDto> getCommissionConfirmList(String email) {
-        Members members = getMemberByEmail(email);
-
-        List<Commission> commissions = commissionRepository.findByMembers(members);
-
-        // 견적이 있는 청소 의뢰 필터링 및 모든 견적 추가
-        List<CommissionConfirmListResponseDto> responseList = new ArrayList<>();
-        for (Commission commission : commissions) {
-            for (Estimate estimate : commission.getEstimates()) {
-                CommissionConfirmListResponseDto dto = convertToConfirmListDto(commission, estimate); // dto 변환
-                responseList.add(dto); // 변환된 dto를 리스트에 추가
-            }
-        }
-        return responseList;
-
-    }
-
-
     // 특정 회원(나) 청소의뢰 내역 전체조회
     public <T> List<T> getMemberCommissionsByEmail(String email, Class<T> responseType) {
 
@@ -163,6 +144,29 @@ public class CommissionService {
 
     }
 
+    //청소견적이 리스트로 붙어있는 청소의뢰 단건조회
+    public CommissionConfirmListResponseDto getCommissionConfirmList(String email, Long commissionId) {
+
+        //회원 찾기
+        Members members = getMemberByEmail(email);
+
+        //청소의뢰 객체 찾기
+        Commission commission = getCommissionByIdAndMember(commissionId, members);
+
+        // 청소의뢰에 속한 견적 리스트 변환
+        List<EstimateResponseDto> estimateDtos = new ArrayList<>();
+        for (Estimate estimate : commission.getEstimates()) {
+            EstimateResponseDto estimateDto = new EstimateResponseDto(estimate);
+            estimateDtos.add(estimateDto);
+        }
+
+        //DTO로 변환
+        CommissionConfirmListResponseDto responseDto = new CommissionConfirmListResponseDto(commission, estimateDtos);
+
+        return responseDto;
+    }
+
+
     //이메일로 회원은 찾는 메서드
     private Members getMemberByEmail(String email) {
         return membersRepository.findByEmail(email)
@@ -199,24 +203,6 @@ public class CommissionService {
         return responseDtoList;
     }
 
-
-    // Commission과 Estimate를 받아서 CommissionConfirmListResponseDto로 변환하는 메서드
-    private CommissionConfirmListResponseDto convertToConfirmListDto(Commission commission, Estimate estimate) {
-        List<EstimateResponseDto> estimateResponseDtos = new ArrayList<>();
-        estimateResponseDtos.add(new EstimateResponseDto(estimate));
-
-        return new CommissionConfirmListResponseDto(
-                commission.getId(),
-                commission.getSize(),
-                commission.getHouseType(),
-                commission.getCleanType(),
-                commission.getDesiredDate(),
-                commission.getSignificant(),
-                commission.getImage(),
-                commission.getStatus(),
-                estimateResponseDtos
-        );
-    }
 
 
     private static final Logger logger = LoggerFactory.getLogger(CommissionService.class);

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -146,6 +146,23 @@ public class CommissionService {
 
     }
 
+    //청소의뢰 단건조회
+    public CommissionConfirmDetailResponseDto getCommissionDetailConfirm(String email, Long commissionId) {
+
+        //이메일로 회원찾기
+        Members members = getMemberByEmail(email);
+
+        //청소의뢰 객체 찾기
+        Commission commission = getCommissionByIdAndMember(commissionId, members);
+
+        //DTO로 변환하기
+        CommissionConfirmDetailResponseDto responseDto = new CommissionConfirmDetailResponseDto(commission);
+
+        //반환하기
+        return responseDto;
+
+    }
+
     //이메일로 회원은 찾는 메서드
     private Members getMemberByEmail(String email) {
         return membersRepository.findByEmail(email)
@@ -200,18 +217,6 @@ public class CommissionService {
                 estimateResponseDtos
         );
     }
-
-    public CommissionConfirmDetailResponseDto getCommissionDetailConfirm(Long estimateId, Long commissionId) {
-
-        Commission commission = commissionRepository.findByEstimatesIdAndId(estimateId, commissionId);
-
-        Estimate estimate = new Estimate();
-        Address address = new Address();
-        CommissionConfirmDetailResponseDto commissionConfirmDetailResponseDto = new CommissionConfirmDetailResponseDto(commission, estimate, address);
-        return commissionConfirmDetailResponseDto;
-    }
-
-
 
 
     private static final Logger logger = LoggerFactory.getLogger(CommissionService.class);


### PR DESCRIPTION
## 🛠️ 작업 내용
- 청소의뢰를 단건으로 조회할 수 있는 API를 만들었습니다.
- 청소의뢰를 단건으로 조회할때 견적들도 함께 나오도록 하는 API를 만들었습니다. 

## ⚡️ Issue number & Link
- #89 

<br/>

## 📝 체크 리스트
- [x] 청소의뢰 단건조회 API
- [x] 청소견적이 리스트로 붙어있는 청소의뢰 단건조회 API

<br/>

