### PR TITLE
refactor : 청소의뢰 단건조회에 주소ID추가

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/CommissionConfirmListResponseDto.java
@@ -23,6 +23,7 @@ public class CommissionConfirmListResponseDto {
     private String significant;
     private String image;
     private StatusType status;
+    private Long addressId;
 
     private List<EstimateResponseDto> estimates;
 
@@ -38,6 +39,7 @@ public class CommissionConfirmListResponseDto {
         this.significant = commission.getSignificant();
         this.image = commission.getImage();
         this.status = commission.getStatus();
+        this.addressId = commission.getAddress().getId();
         this.estimates = estimateDtos;
     }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 견적 리스트가 있는 청소의뢰를 단건조회시 주소ID 가 빠져있는것을 추가했습니다.

<br/>

## ⚡️ Issue number & Link
- #89 


<br/>

## 📝 체크 리스트
- [ ] 견적 리스트가 있는 청소의뢰 단건조회에 주소ID추가

<br/>