### PR TITLE
refactor : 성능테스트 개선 findByMembersId N+1 문제 해결

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
+++ b/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
@@ -3,6 +3,7 @@ package com.clean.cleanroom.commission.repository;
 import com.clean.cleanroom.commission.entity.Commission;
 import com.clean.cleanroom.enums.StatusType;
 import com.clean.cleanroom.members.entity.Members;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Optional;
 
 public interface CommissionRepository extends JpaRepository<Commission, Long> {
 
+    @EntityGraph(attributePaths = {"members", "address", "estimates"})
     Optional<List<Commission>> findByMembersId(Long membersId);
 
     Optional<Commission> findByIdAndMembersId(Long id, Long membersId);


### PR DESCRIPTION
## 🛠️ 작업 내용
- findByMembersId를 호출할 시 해당 회원에 대한 모든 Commission 객체가 반환되며 
 연관된 Members, Address, Estimate 객체를 접근할 때마다 추가적인 쿼리가 발생하는 N+1 문제를 해결하였습니다.

<br/>

## ⚡️ Issue number & Link
- #95  

<br/>

## 📝 체크 리스트
- [ ] @EntityGraph를 사용하여 Members와 Address를 미리 로드

<br/>