### PR TITLE
Refactor : 성능테스트 개선 캐싱적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,10 +47,15 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
     testImplementation 'org.hamcrest:hamcrest:2.2'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     //logging
     implementation 'ch.qos.logback:logback-classic'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'
+
+    //Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/clean/cleanroom/CleanRoomApplication.java
+++ b/src/main/java/com/clean/cleanroom/CleanRoomApplication.java
@@ -2,8 +2,10 @@ package com.clean.cleanroom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class CleanRoomApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
+++ b/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
@@ -5,13 +5,15 @@ import com.clean.cleanroom.enums.StatusType;
 import com.clean.cleanroom.members.entity.Members;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CommissionRepository extends JpaRepository<Commission, Long> {
 
-    @EntityGraph(attributePaths = {"members", "address", "estimates"})
+    @EntityGraph(attributePaths = {"members", "address", "estimates"}) //@EntityGraph를 사용하여 Members와 Address, estimates를 미리 로드
     Optional<List<Commission>> findByMembersId(Long membersId);
 
     Optional<Commission> findByIdAndMembersId(Long id, Long membersId);
@@ -19,4 +21,8 @@ public interface CommissionRepository extends JpaRepository<Commission, Long> {
     List<Commission> findByMembers(Members members);
 
     Commission findByEstimatesIdAndId(Long estimateId, Long commissionId);
+
+    // 특정 회원이 생성한 가장 최근의 청소의뢰를 가져오는 기능
+    Optional<Commission> findTopByMembersIdOrderByIdDesc(Long membersId);
+
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 청소의뢰 생성, 수정, 조회, 삭제 등을 할때 → 내가 작성한 청소의뢰 목록이 뜨게됩니다.
여러번 같은 요청을 보냈을때 이것을 캐시로 처리하면 응답시간을 빠르게 줄일 수 있습니다.
- 단! 문제는 캐시 처리로 하게되면 방금 생성한 청소 의뢰는 안나오게 됩니다.
따라서 캐시 + 실시간 데이터 병합하는 방법을 사용하여 
청소의뢰를 하고 내가 작성한 의뢰 리스트를 불러오더라도 → 방금 작성한 청소 의뢰가 보일 수 있도록 하였습니다.

<br/>

## ⚡️ Issue number & Link
- #95 

<br/>

## 📝 체크 리스트
- [x] 청소의뢰 내역을 캐시에서 가져오기
- [x] 청소의뢰 생성 후 실시간 데이터와 캐시 데이터 병합
- [x] 청소의뢰가 수정되거나 삭제될 때 캐시를 무효화

<br/>
