### PR TITLE
test  : 테스트 커버리지 리포팅을 위한 JaCoCo 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco' // JaCoCo 플러그인 추가
 }
 
 group = 'com.clean'
@@ -47,17 +48,48 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:4.0.0'
     testImplementation 'org.hamcrest:hamcrest:2.2'
-    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     //logging
     implementation 'ch.qos.logback:logback-classic'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'
 
-    //Cache
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
-
+    // JaCoCo 의존성 추가 (별도의 의존성 필요 없음, 플러그인만으로 충분)
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// JaCoCo 설정
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+tasks.jacocoTestReport {
+    dependsOn tasks.test // 테스트가 실행된 후에 리포트를 생성하도록 설정
+    reports {
+        xml.required.set(true) // XML 리포트 생성
+        csv.required.set(false) // CSV 리포트는 생성하지 않음
+        html.required.set(true) // HTML 리포트 생성
+
+        html.destination file("jacoco/jacocoHtml")
+        xml.destination file("jacoco/jacoco.xml")
+    }
+}
+
+
+// 커버리지 퍼센테이지와 범위 설정
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS' //클래스 단위 체크
+
+//            // 브랜치 커버리지의 최소값
+//            limit {
+//                counter = 'BRANCH'
+//                value = 'COVEREDRATIO'
+//                minimum = 0.50
+//            }
+        }
+    }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 테스트 커버리지 리포트 생성 및 검증을 위한 설정 적용
- 

<br/>

## ⚡️ Issue number & Link
- #48 
- 

<br/>

## 📝 체크 리스트
- [ ] jacoco를 통해 커버리지 테스트 리포트 생성