### PR TITLE
refactor : 성능 테스트 개선 내 청소의뢰 내역 조회 N+1문제 해결

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/entity/Commission.java
+++ b/src/main/java/com/clean/cleanroom/commission/entity/Commission.java
@@ -26,11 +26,11 @@ public class Commission {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "members_id")
     private Members members;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "address_id")
     private Address address;
 

--- a/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
+++ b/src/main/java/com/clean/cleanroom/commission/repository/CommissionRepository.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 public interface CommissionRepository extends JpaRepository<Commission, Long> {
 
-    @EntityGraph(attributePaths = {"members", "address", "estimates"}) //@EntityGraph를 사용하여 Members와 Address, estimates를 미리 로드
     Optional<List<Commission>> findByMembersId(Long membersId);
 
     Optional<Commission> findByIdAndMembersId(Long id, Long membersId);


### PR DESCRIPTION
## 🛠️ 작업 내용
- 내 청소의뢰 조회시 쿼리는 2번 나가야하지만 4번나가는 현상이 있었습니다.
@EntityGraph 로 해결해봤지만 → 결론적으로는 쿼리가 엄청나게 길어지는 현상이 나타났습니다.
ManyToOne 기본설정이 즉시로딩으로 되어있음으로 → 지연로딩으로 바꿔주었습니다.  
쿼리가 2번만 나가는 것을 확인했고 N+1 문제 해결하였습니다. (응답시간: 188ms → 148ms 로 개선)

<br/>

## ⚡️ Issue number & Link
- #95 

<br/>

## 📝 체크 리스트
- [ ] N+1 문제 지연로딩으로 해경

<br/>

