### PR TITLE
refactor : 성능 테스트 개선 네이티브 쿼리 사용으로 공간복잡도 확보

### DIFF
--- a/src/main/java/com/clean/cleanroom/commission/dto/MyCommissionResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/commission/dto/MyCommissionResponseDto.java
@@ -22,9 +22,9 @@ public class MyCommissionResponseDto {
     private StatusType status;
 
 
-    public MyCommissionResponseDto(Commission commission) {
+    public MyCommissionResponseDto(Commission commission, String memberNick) {
         this.commissionId = commission.getId();
-        this.memberNick = commission.getMembers().getNick();
+        this.memberNick = memberNick;
         this.size = commission.getSize();
         this.houseType = commission.getHouseType();
         this.cleanType = commission.getCleanType();

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -7,6 +7,7 @@ import com.clean.cleanroom.estimate.dto.EstimateResponseDto;
 import com.clean.cleanroom.estimate.entity.Estimate;
 import com.clean.cleanroom.exception.CustomException;
 import com.clean.cleanroom.exception.ErrorMsg;
+import com.clean.cleanroom.members.dto.MemberIdAndNickDto;
 import com.clean.cleanroom.members.entity.Address;
 import com.clean.cleanroom.members.entity.Members;
 import com.clean.cleanroom.members.repository.AddressRepository;
@@ -103,39 +104,25 @@ public class CommissionService {
     @Transactional(readOnly = true)
     public  List<MyCommissionResponseDto> getMemberCommissionsByEmail(String email) {
 
-        //회원 찾기
-        Members members = getMemberByEmail(email);
+        //회원 ID와 닉네임 가져오기
+        MemberIdAndNickDto memberInfo = membersRepository.findMemberIdByEmailNative(email);
+        Long membersId = memberInfo.getId();
+        String membernick = memberInfo.getNick();
 
         //청소의뢰 객체 찾기 (리스트로)
-        List<Commission> commissions = commissionRepository.findByMembersId(members.getId())
+        List<Commission> commissions = commissionRepository.findByMembersId(membersId)
                 .orElseThrow(() -> new CustomException(ErrorMsg.MEMBER_NOT_FOUND));
 
         // Commission 리스트를 MyCommissionResponseDto 리스트로 변환
         List<MyCommissionResponseDto> commissionResponseDtos = new ArrayList<>();
         for (Commission commission : commissions) {
-            commissionResponseDtos.add(new MyCommissionResponseDto(commission));
+            commissionResponseDtos.add(new MyCommissionResponseDto(commission, membernick));
         }
 
         //변환된 Dto리스트 반환
         return commissionResponseDtos;
     }
 
-
-    //전체 청소의뢰를 조회하는 서비스
-    public List<MyCommissionResponseDto> getAllCommissions() {
-
-        //청소의뢰 객체 전체 찾기
-        List<Commission> commissions = commissionRepository.findAll();
-
-        //찾은 청소 의뢰 객체들을 담아줄 DTO리스트 생성
-        List<MyCommissionResponseDto> responseDtoList = new ArrayList<>();
-        for (Commission commission : commissions) {
-            responseDtoList.add(new MyCommissionResponseDto(commission)); //for 문으로 하나씩 담아주기
-        }
-
-        return responseDtoList;
-
-    }
 
     //청소의뢰 단건조회
     public CommissionConfirmDetailResponseDto getCommissionDetailConfirm(String email, Long commissionId) {
@@ -182,6 +169,7 @@ public class CommissionService {
         return membersRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorMsg.MEMBER_NOT_FOUND));
     }
+
 
     //주소 찾는 메서드
     private Address getAddressById(Long addressId) {

--- a/src/main/java/com/clean/cleanroom/members/dto/MemberIdAndNickDto.java
+++ b/src/main/java/com/clean/cleanroom/members/dto/MemberIdAndNickDto.java
@@ -1,0 +1,14 @@
+package com.clean.cleanroom.members.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberIdAndNickDto {
+    private Long id;
+    private String nick;
+
+    public MemberIdAndNickDto(Long id, String nick) {
+        this.id = id;
+        this.nick = nick;
+    }
+}

--- a/src/main/java/com/clean/cleanroom/members/repository/MembersRepository.java
+++ b/src/main/java/com/clean/cleanroom/members/repository/MembersRepository.java
@@ -1,7 +1,11 @@
 package com.clean.cleanroom.members.repository;
 
+import com.clean.cleanroom.members.dto.MemberIdAndNickDto;
 import com.clean.cleanroom.members.entity.Members;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
 public interface MembersRepository extends JpaRepository<Members, Long> {
@@ -9,4 +13,7 @@ public interface MembersRepository extends JpaRepository<Members, Long> {
     boolean existsByEmail(String email);
     boolean existsByNick(String nick);
     boolean existsByPhoneNumber(String phoneNumber);
+
+    @Query("SELECT new com.clean.cleanroom.members.dto.MemberIdAndNickDto(m.id, m.nick) from Members m WHERE m.email = :email")
+    MemberIdAndNickDto findMemberIdByEmailNative(@Param("email") String email);
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 내 청소 의뢰 내역을 전체조회 할때 멤버의 ID와 닉네임이 필요합니다.
이를 위해 멤버 객체를 만들게 되면서 멤버의 모든 필드를 가져오게됩니다.
- 그러나 네이티브 쿼리를 사용함으로 멤버의 ID와 닉네임만 가져오도록 만들었고 
이를통해 공간복잡도와 쿼리호출의 시간복잡도를 개선하였습니다.

<br/>

## ⚡️ Issue number & Link
- #95  

<br/>

## 📝 체크 리스트
- [x] 네이티브 쿼리 사용으로 공간복잡도 확보

<br/>
