### PR TITLE
refactor : 성능 테스트 개선 내 청소의뢰 내역 전체조회에 캐싱적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic'
     implementation 'net.logstash.logback:logstash-logback-encoder:7.0.1'
 
+    //cache
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 
 }
 

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -16,6 +16,8 @@ import com.clean.cleanroom.util.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -48,6 +50,7 @@ public class CommissionService {
     }
 
     //청소의뢰 생성 서비스
+    @CacheEvict(value = "commissionCache", key = "#email")
     public CommissionCreateResponseDto createCommission(String email, CommissionCreateRequestDto requestDto) {
 
         //의뢰한 회원찾기
@@ -64,6 +67,7 @@ public class CommissionService {
 
     //청소의로 수정 서비스
     @Transactional
+    @CacheEvict(value = "commissionCache", key = "#email")
     public CommissionUpdateResponseDto updateCommission(String email, Long commissionId, Long addressId, CommissionUpdateRequestDto requestDto) {
 
         //수정할 회원 찾기
@@ -85,6 +89,7 @@ public class CommissionService {
     }
 
     //청소의뢰 취소 서비스
+    @CacheEvict(value = "commissionCache", key = "#email")
     public CommissionCancelResponseDto cancelCommission(String email, Long commissionId) {
 
         //회원 찾기
@@ -102,7 +107,8 @@ public class CommissionService {
 
     // 특정 회원(나) 청소의뢰 내역 전체조회
     @Transactional(readOnly = true)
-    public  List<MyCommissionResponseDto> getMemberCommissionsByEmail(String email) {
+    @Cacheable(value = "commissionCache", key = "#email")
+    public List<MyCommissionResponseDto> getMemberCommissionsByEmail(String email) {
 
         //회원 ID와 닉네임 가져오기
         MemberIdAndNickDto memberInfo = membersRepository.findMemberIdByEmailNative(email);

--- a/src/main/java/com/clean/cleanroom/config/CacheConfig.java
+++ b/src/main/java/com/clean/cleanroom/config/CacheConfig.java
@@ -1,0 +1,23 @@
+package com.clean.cleanroom.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES) //10분 후 캐시만료
+                .maximumSize(10000));  // 최대 10000개의 캐시 아이템 저장
+
+        return cacheManager;
+    }
+}

--- a/src/test/java/com/clean/cleanroom/commission/service/CommissionServiceTest.java
+++ b/src/test/java/com/clean/cleanroom/commission/service/CommissionServiceTest.java
@@ -1,0 +1,90 @@
+package com.clean.cleanroom.commission.service;
+
+import com.clean.cleanroom.commission.dto.CommissionCreateRequestDto;
+import com.clean.cleanroom.commission.dto.MyCommissionResponseDto;
+import com.clean.cleanroom.commission.repository.CommissionRepository;
+import com.clean.cleanroom.enums.CleanType;
+import com.clean.cleanroom.enums.HouseType;
+import com.clean.cleanroom.members.repository.MembersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@EnableCaching
+public class CommissionServiceTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CommissionServiceTest.class);
+    @Autowired
+    private CommissionService commissionService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private MembersRepository membersRepository;
+
+    @Autowired
+    private CommissionRepository commissionRepository;
+
+    private CommissionCreateRequestDto requestDto;
+
+    private String testEmail = "aaaaa@naver.com";
+
+    @BeforeEach
+    void setUp() {
+//        requestDto = new CommissionCreateRequestDto();
+//        requestDto.setAddressId(1L); // 예시 데이터
+//        requestDto.setCleanType(CleanType.NORMAL); // 예시 데이터
+//        requestDto.setHouseType(HouseType.APT); // 예시 데이터
+//        requestDto.setSize(100); // 예시 데이터
+//        requestDto.setDesiredDate(LocalDateTime.now().plusDays(3)); // 예시 데이터
+//        requestDto.setSignificant("Test request"); // 예시 데이터
+//        requestDto.setImage("test_image.png"); // 예시 데이터
+    }
+
+    @Test
+    @Transactional
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
+    void testCachingOnMemberCommissionRetrieval() {
+
+        // 1. 처음 청소의뢰 내역 조회 -> DB에서 조회되어야 함
+        List<MyCommissionResponseDto> commissions = commissionService.getMemberCommissionsByEmail(testEmail);
+        assertNotNull(commissions);
+        log.info("처음 청소의뢰 내역 조회 -> DB에서 조회되어야 함");
+
+        // 2. 캐시에 저장되었는지 확인
+        List<MyCommissionResponseDto> cachedCommissions = cacheManager.getCache("commissionCache")
+                .get(testEmail, List.class);
+        assertNotNull(cachedCommissions);
+        assertEquals(commissions.size(), cachedCommissions.size());
+        log.info("캐시에 저장되었는지 확인");
+
+        // 3. 다시 청소의뢰 내역 조회 -> 캐시에서 조회되어야 함
+        List<MyCommissionResponseDto> cachedResult = commissionService.getMemberCommissionsByEmail(testEmail);
+        assertEquals(commissions.size(), cachedResult.size());
+        log.info("다시 청소의뢰 내역 조회 -> 캐시에서 조회되어야 함");
+
+        // 4. 캐시 무효화 테스트 (예: 청소의뢰 생성)
+        commissionService.createCommission(testEmail, requestDto);
+        List<MyCommissionResponseDto> newCommissions = commissionService.getMemberCommissionsByEmail(testEmail);
+        log.info("캐시 무효화 테스트 (예: 청소의뢰 생성)");
+
+        // 5. 캐시가 무효화된 후 새로 조회된 데이터와 기존 캐시 데이터가 일치하지 않아야 함
+        assertEquals(newCommissions.size(), commissionRepository.findByMembersId(membersRepository.findMemberIdByEmailNative(testEmail).getId()).get().size());
+        log.info("캐시가 무효화된 후 새로 조회된 데이터와 기존 캐시 데이터가 일치하지 않아야 함");
+    }
+}


### PR DESCRIPTION
## 🛠️ 작업 내용
- 내 청소의뢰 내역을 조회할때 캐싱을 사용하도록 적용하였습니다.
- 청소 의뢰 생성, 수정, 취소 등 데이터의 변경이 일어났을 때는 
캐시를 무효화 하여 누락되는 데이터가 없도록 하였습니다.
- 테스트 코드를 작성하여 캐싱이 잘 적용되었는지 확인하였습니다.

<br/>

## ⚡️ Issue number & Link
- #95 

<br/>

## 📝 체크 리스트
- [x] 내 청소의뢰 내역 조회시 캐싱을 사용하도록 적용
- [x] 청소 의뢰 생성, 수정, 취소 등 데이터의 변경이 일어나면 캐싱을 무효화
- [x] 캐싱이 적용되었는지 테스트 코드를 작성하여 확인

<br/>