### PR TITLE
refactor : redis를 활용하여 이메일 인증 코드 관리

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -15,5 +15,17 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="0@localhost" uuid="1b0d0134-b76c-447d-8990-2bd97336fabd">
+      <driver-ref>redis</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>jdbc.RedisDriver</jdbc-driver>
+      <jdbc-url>jdbc:redis://localhost:6379/0</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,8 @@ dependencies {
     //cache
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
-
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/src/main/java/com/clean/cleanroom/config/RedisConfig.java
+++ b/src/main/java/com/clean/cleanroom/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.clean.cleanroom.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        // Redis 연결 팩토리 설정
+        template.setConnectionFactory(redisConnectionFactory);
+
+        // 키는 String으로, 값은 기본적으로 직렬화된 객체로 설정
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+
+        // 옵션: Hash의 키와 값에 대한 직렬화 설정
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        template.setEnableTransactionSupport(true); // 트랜잭션 지원 여부
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/clean/cleanroom/exception/ErrorMsg.java
+++ b/src/main/java/com/clean/cleanroom/exception/ErrorMsg.java
@@ -31,6 +31,8 @@ public enum ErrorMsg {
     EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, 2006, "이메일 인증이 완료되지 않았습니다."),
     EXPIRED_VERIFICATION_CODE(HttpStatus.UNAUTHORIZED, 2007, "이메일 인증 코드가 만료되었습니다."),
     VERIFICATION_CODE_ATTEMPTS_EXCEEDED(HttpStatus.UNAUTHORIZED, 2008, "인증 시도 횟수 초과입니다."),
+    UNAUTHORIZED_EMAIL(HttpStatus.UNAUTHORIZED, 2009, "해당 이메일에 대한 인증 코드를 찾을 수 없습니다."),
+
 
 
     /* 403 FORBIDDEN : 권한 없음 */

--- a/src/main/java/com/clean/cleanroom/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clean/cleanroom/exception/GlobalExceptionHandler.java
@@ -40,6 +40,13 @@ public class GlobalExceptionHandler {
         return ResponseDto.toExceptionResponseEntity(HttpStatus.UNAUTHORIZED, 2000);
     }
 
+    // UnAuthenticationException 처리
+    @ExceptionHandler(value = {UnAuthenticationException.class})
+    protected ResponseEntity<ResponseDto> handleUnAuthenticationException(UnAuthenticationException e) {
+        log.error("UnAuthenticationException occurred: {}", e.getMessage());
+        return ResponseDto.toExceptionResponseEntity(HttpStatus.UNAUTHORIZED, 4000);
+    }
+
     // 500 error
     @ExceptionHandler({Exception.class})
     public ResponseEntity<ResponseDto> handleAll(final Exception ex) {
@@ -52,4 +59,5 @@ public class GlobalExceptionHandler {
         log.error("IOException occurred: ", ex);
         return ResponseDto.toExceptionResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, 9998);
     }
+
 }

--- a/src/main/java/com/clean/cleanroom/exception/UnAuthenticationException.java
+++ b/src/main/java/com/clean/cleanroom/exception/UnAuthenticationException.java
@@ -1,0 +1,23 @@
+package com.clean.cleanroom.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+// 예외가 발생할 때 자동으로 401 Unauthorized 상태 반환
+
+public class UnAuthenticationException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String details;  // 추가된 필드
+
+    // ErrorMsg를 반환하는 메서드 추가
+    private final ErrorMsg errorMsg;  // ErrorMsg 필드 추가
+
+    public UnAuthenticationException(ErrorMsg errorMsg) {
+        super(errorMsg.getDetails());
+        this.httpStatus = errorMsg.getHttpStatus();
+        this.code = errorMsg.getCode();
+        this.details = errorMsg.getDetails();  // 추가된 필드 초기화
+        this.errorMsg = errorMsg;
+    }
+}

--- a/src/main/java/com/clean/cleanroom/members/service/MembersService.java
+++ b/src/main/java/com/clean/cleanroom/members/service/MembersService.java
@@ -3,90 +3,63 @@ package com.clean.cleanroom.members.service;
 import com.clean.cleanroom.enums.LoginType;
 import com.clean.cleanroom.exception.CustomException;
 import com.clean.cleanroom.exception.ErrorMsg;
+import com.clean.cleanroom.exception.UnAuthenticationException;
 import com.clean.cleanroom.members.dto.*;
 import com.clean.cleanroom.members.entity.Members;
-import com.clean.cleanroom.members.entity.VerificationCode;
 import com.clean.cleanroom.members.repository.MembersRepository;
-import com.clean.cleanroom.members.repository.VerificationCodeRepository;
+import com.clean.cleanroom.redis.RedisService;
 import com.clean.cleanroom.util.JwtUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.Random;
 
 
 @Service
 public class MembersService {
-    private final MembersRepository membersRepository;
-    private final VerificationCodeRepository verificationCodeRepository;
 
-    public MembersService(
-            MembersRepository membersRepository,
-            VerificationCodeRepository verificationCodeRepository) {
+    private final MembersRepository membersRepository;
+    private final RedisService redisService;
+
+    public MembersService(MembersRepository membersRepository, RedisService redisService) {
         this.membersRepository = membersRepository;
-        this.verificationCodeRepository = verificationCodeRepository;
+        this.redisService = redisService;
     }
 
-    // 이메일 인증 코드를 생성하고 데이터베이스에 저장하거나 업데이트하는 메서드
+    // 이메일 인증 코드를 생성하고 Redis에 저장하는 메서드
     @Transactional
     public String generateEmailVerificationCode(String email) {
         // 6자리 랜덤 인증 코드 생성
         String verificationCode = generateVerificationCode();
-        // 인증 코드의 만료 시간을 현재 시간으로부터 10분 후로 설정
-        LocalDateTime expirationTime = LocalDateTime.now().plusMinutes(10);
 
-        // 이메일로 기존에 저장된 인증 코드가 있는지 확인
-        Optional<VerificationCode> optionalVerificationCode = verificationCodeRepository.findByEmail(email);
-        if (optionalVerificationCode.isPresent()) {
-            // 기존 코드가 있으면 코드와 만료 시간을 업데이트
-            VerificationCode existingCode = optionalVerificationCode.get();
-            existingCode.updateCodeAndExpiration(verificationCode, expirationTime);
-            verificationCodeRepository.save(existingCode);
-        } else {
-            // 기존 코드가 없으면 새로운 인증 코드 생성
-            VerificationCode newCode = new VerificationCode(email, verificationCode, expirationTime);
-            verificationCodeRepository.save(newCode);
-        }
+        // Redis에 인증 코드 저장 (3분 동안 유효)
+        redisService.setCode(email, verificationCode);
 
         return verificationCode;
     }
 
     // 랜덤한 6자리 숫자 인증 코드를 생성하는 메서드
     private String generateVerificationCode() {
-        // 0부터 999999 사이의 랜덤 숫자를 생성하여 6자리 문자열로 반환
         return String.format("%06d", new Random().nextInt(999999));
     }
 
-    // 사용자가 입력한 이메일과 인증 코드를 검증하는 메서드
     @Transactional
     public void verifyEmail(String email, String code) {
-        // 이메일에 해당하는 인증 코드 조회, 없으면 예외 발생
-        VerificationCode storedCode = verificationCodeRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException(ErrorMsg.INVALID_VERIFICATION_CODE));
+        // Redis에서 인증 코드 조회
+        String storedCode = redisService.getCode(email);
 
-        // 인증 코드가 만료되었는지 확인
-        if (storedCode.isExpired()) {
-            throw new CustomException(ErrorMsg.EXPIRED_VERIFICATION_CODE);
-        }
-
-        // 사용자가 입력한 코드가 저장된 코드와 일치하는지 확인
-        if (!storedCode.getCode().equals(code)) {
+        // 사용자가 입력한 코드와 Redis에 저장된 코드가 일치하는지 확인
+        if (!storedCode.equals(code)) {
             throw new CustomException(ErrorMsg.INVALID_VERIFICATION_CODE);
         }
-
-        // 인증 완료 상태로 변경
-        storedCode.markAsVerified();
-        verificationCodeRepository.save(storedCode);
+        // 이메일 인증이 완료되었다고 Redis에 플래그 저장
+        redisService.setVerifiedFlag(email);
     }
 
     // 사용자의 이메일이 인증되었는지 확인하는 메서드
     public boolean isEmailVerified(String email) {
-        // 이메일에 해당하는 인증 코드가 존재하고, 인증되었는지 여부를 반환
-        return verificationCodeRepository.findByEmail(email)
-                .map(VerificationCode::isVerified)
-                .orElse(false);
+        // Redis에서 이메일 인증이 완료된 플래그가 있는지 확인
+        return redisService.isVerified(email);
     }
 
     @Transactional

--- a/src/main/java/com/clean/cleanroom/redis/RedisService.java
+++ b/src/main/java/com/clean/cleanroom/redis/RedisService.java
@@ -1,0 +1,47 @@
+package com.clean.cleanroom.redis;
+
+import com.clean.cleanroom.exception.CustomException;
+import com.clean.cleanroom.exception.ErrorMsg;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 인증 코드 저장
+    public void setCode(String email, String code) {
+        ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
+        // 인증 코드를 5분(300초) 동안 저장
+        valOperations.set(email, code, 300, TimeUnit.SECONDS);
+    }
+
+    // 인증 코드 조회
+    public String getCode(String email) {
+        ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
+        Object code = valOperations.get(email);
+        if (code == null) {
+            throw new CustomException(ErrorMsg.INVALID_VERIFICATION_CODE);
+        }
+        return code.toString();
+    }
+
+    // 인증 완료 플래그 설정
+    public void setVerifiedFlag(String email) {
+        ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
+        // 인증이 완료되면 인증 플래그를 Redis에 영구적으로 저장
+        valOperations.set(email + "_verified", "true", 10, TimeUnit.MINUTES); // 만료 시간을 원하면 설정 가능
+    }
+
+    // 인증 완료 여부 확인
+    public boolean isVerified(String email) {
+        ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
+        Object verifiedFlag = valOperations.get(email + "_verified");
+        return verifiedFlag != null && verifiedFlag.equals("true");
+    }
+}

--- a/src/main/java/com/clean/cleanroom/util/ResponseDto.java
+++ b/src/main/java/com/clean/cleanroom/util/ResponseDto.java
@@ -1,7 +1,5 @@
 package com.clean.cleanroom.util;
 
-import com.clean.cleanroom.exception.ErrorMsg;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,3 +36,11 @@ spring.mail.username=wjdwo3427@gmail.com
 spring.mail.password=dtimcvrhtwdstosn
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.data.redis.timeout=60000
+spring.data.redis.lettuce.pool.max-active=8
+spring.data.redis.lettuce.pool.max-idle=8
+spring.data.redis.lettuce.pool.min-idle=0


### PR DESCRIPTION
## 🛠️ 작업 내용
- Redis는 메모리에 데이터를 저장하고 빠른 읽기와 쓰기 속도가 
- RDBMS(관계형 DB)보다 훨씬 빠릅니다.
- 데이터를 저장할 때 TTL을 설정하여 자동 삭제를 할 수 있습니다.
- 그래서 이메일 인증코드 데이터를 Redis에 저장하는 걸로 변경했습니다.
<br/>

## ⚡️ Issue number & Link
- #124  

<br/>

## 📝 체크 리스트
- [x] Config 설정
- [x] service 기본 메서드 설정
- [x] 예외 처리 설정

<br/>
