### PR TITLE
Feat : 성능태스트 개선  redis 활용한 조회로직에 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,10 @@ dependencies {
     //cache
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.6'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.1'
 
 }
 

--- a/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
+++ b/src/main/java/com/clean/cleanroom/commission/service/CommissionService.java
@@ -12,6 +12,7 @@ import com.clean.cleanroom.members.entity.Address;
 import com.clean.cleanroom.members.entity.Members;
 import com.clean.cleanroom.members.repository.AddressRepository;
 import com.clean.cleanroom.members.repository.MembersRepository;
+import com.clean.cleanroom.redis.RedisService;
 import com.clean.cleanroom.util.JwtUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 
 @Service
@@ -38,16 +40,17 @@ public class CommissionService {
     private final CommissionRepository commissionRepository;
     private final MembersRepository membersRepository;
     private final AddressRepository addressRepository;
+    private final RedisService redisService;
 
 
-    public CommissionService(CommissionRepository commissionRepository, MembersRepository membersRepository, AddressRepository addressRepository) {
+    public CommissionService(CommissionRepository commissionRepository, MembersRepository membersRepository, AddressRepository addressRepository, RedisService redisService) {
         this.commissionRepository = commissionRepository;
         this.membersRepository = membersRepository;
         this.addressRepository = addressRepository;
+        this.redisService = redisService;
     }
 
     //청소의뢰 생성 서비스
-    @CacheEvict(value = "commissionCache", key = "#email")
     public CommissionCreateResponseDto createCommission(String email, CommissionCreateRequestDto requestDto) {
 
         //의뢰한 회원찾기
@@ -57,14 +60,17 @@ public class CommissionService {
         Address address = getAddressById(requestDto.getAddressId());
 
         //청소의뢰 객채 생성 + 저장
-        saveCommission(members, address, requestDto);
+        Commission commission = saveCommission(members, address, requestDto);
+
+        // Redis에 저장된 기존 의뢰 정보 삭제
+        String cacheKey = email; // Redis에서 사용한 캐시 키와 동일한 키 사용
+        redisService.deleteObject(cacheKey);
 
         return new CommissionCreateResponseDto();
     }
 
     //청소의로 수정 서비스
     @Transactional
-    @CacheEvict(value = "commissionCache", key = "#email")
     public CommissionUpdateResponseDto updateCommission(String email, Long commissionId, Long addressId, CommissionUpdateRequestDto requestDto) {
 
         //수정할 회원 찾기
@@ -79,6 +85,10 @@ public class CommissionService {
         //청소의뢰를 업데이트(요청데이터와, 수정주소)
         commission.update(requestDto, address);
 
+        // Redis에 저장된 기존 의뢰 정보 삭제
+        String cacheKey = email; // Redis에서 사용한 캐시 키와 동일한 키 사용
+        redisService.deleteObject(cacheKey);
+
         //업데이트 된 청소의뢰 엔티티를 -> DTO로 변환해 반환하기
         CommissionUpdateResponseDto responseDto = new CommissionUpdateResponseDto(commission);
 
@@ -86,7 +96,6 @@ public class CommissionService {
     }
 
     //청소의뢰 취소 서비스
-    @CacheEvict(value = "commissionCache", key = "#email")
     public CommissionCancelResponseDto cancelCommission(String email, Long commissionId) {
 
         //회원 찾기
@@ -98,14 +107,25 @@ public class CommissionService {
         //청소 의뢰 삭제
         commissionRepository.delete(commission);
 
+        // Redis에 저장된 기존 의뢰 정보 삭제
+        String cacheKey = email; // Redis에서 사용한 캐시 키와 동일한 키 사용
+        redisService.deleteObject(cacheKey);
+
         //메시지 반환
         return new CommissionCancelResponseDto();
     }
 
     // 특정 회원(나) 청소의뢰 내역 전체조회
     @Transactional(readOnly = true)
-    @Cacheable(value = "commissionCache", key = "#email")
     public List<MyCommissionResponseDto> getMemberCommissionsByEmail(String email) {
+
+        System.out.println("시작");
+        // Redis에 데이터가 있는지 확인
+        List<MyCommissionResponseDto> cachedResponse = redisService.getObject(email, List.class);
+        if (cachedResponse != null) {
+            return cachedResponse;  // Redis에서 가져온 값 반환
+        }
+        System.out.println("Redis에 데이터가 있는지 확인 = ");
 
         //회원 ID와 닉네임 가져오기
         MemberIdAndNickDto memberInfo = membersRepository.findMemberIdByEmailNative(email);
@@ -115,12 +135,16 @@ public class CommissionService {
         //청소의뢰 객체 찾기 (리스트로)
         List<Commission> commissions = commissionRepository.findByMembersId(membersId)
                 .orElseThrow(() -> new CustomException(ErrorMsg.MEMBER_NOT_FOUND));
+        System.out.println("청소의뢰 객체 찾기 DB");
 
         // Commission 리스트를 MyCommissionResponseDto 리스트로 변환
         List<MyCommissionResponseDto> commissionResponseDtos = new ArrayList<>();
         for (Commission commission : commissions) {
             commissionResponseDtos.add(new MyCommissionResponseDto(commission, membernick));
         }
+
+        // Redis에 변환된 Dto 리스트 저장
+        redisService.setObject(email, commissionResponseDtos, 10, TimeUnit.MINUTES);
 
         //변환된 Dto리스트 반환
         return commissionResponseDtos;
@@ -253,8 +277,11 @@ public class CommissionService {
 
     //필요한 부분만 트랜잭셔널 처리를 하도록 save메서드를 따로 빼기
     @Transactional
-    protected void saveCommission(Members members, Address address, CommissionCreateRequestDto requestDto) {
+    protected Commission saveCommission(Members members, Address address, CommissionCreateRequestDto requestDto) {
         Commission commission = new Commission(members, address, requestDto);
         commissionRepository.save(commission);
+
+        return commission;
     }
+
 }

--- a/src/main/java/com/clean/cleanroom/config/RedisConfig.java
+++ b/src/main/java/com/clean/cleanroom/config/RedisConfig.java
@@ -1,9 +1,13 @@
 package com.clean.cleanroom.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -16,15 +20,27 @@ public class RedisConfig {
         // Redis 연결 팩토리 설정
         template.setConnectionFactory(redisConnectionFactory);
 
-        // 키는 String으로, 값은 기본적으로 직렬화된 객체로 설정
+        // ObjectMapper 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());  // Java 8 Date/Time 모듈 추가
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);  // ISO-8601 포맷으로 날짜 처리
+
+        // GenericJackson2JsonRedisSerializer에 ObjectMapper 적용
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        // 키는 String으로 직렬화
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
 
-        // 옵션: Hash의 키와 값에 대한 직렬화 설정
+        // 값은 JSON으로 직렬화하여 객체를 저장 가능하게 설정
+        template.setValueSerializer(serializer);
+
+        // Hash의 키와 값에 대한 직렬화 설정
         template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
 
-        template.setEnableTransactionSupport(true); // 트랜잭션 지원 여부
+        // 트랜잭션 지원 여부 설정
+        template.setEnableTransactionSupport(true);
+
         template.afterPropertiesSet();
         return template;
     }

--- a/src/main/java/com/clean/cleanroom/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/clean/cleanroom/exception/GlobalExceptionHandler.java
@@ -40,13 +40,6 @@ public class GlobalExceptionHandler {
         return ResponseDto.toExceptionResponseEntity(HttpStatus.UNAUTHORIZED, 2000);
     }
 
-    // UnAuthenticationException 처리
-    @ExceptionHandler(value = {UnAuthenticationException.class})
-    protected ResponseEntity<ResponseDto> handleUnAuthenticationException(UnAuthenticationException e) {
-        log.error("UnAuthenticationException occurred: {}", e.getMessage());
-        return ResponseDto.toExceptionResponseEntity(HttpStatus.UNAUTHORIZED, 4000);
-    }
-
     // 500 error
     @ExceptionHandler({Exception.class})
     public ResponseEntity<ResponseDto> handleAll(final Exception ex) {
@@ -60,4 +53,10 @@ public class GlobalExceptionHandler {
         return ResponseDto.toExceptionResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, 9998);
     }
 
+    // UnAuthenticationException 처리
+    @ExceptionHandler(value = {UnAuthenticationException.class})
+    protected ResponseEntity<ResponseDto> handleUnAuthenticationException(UnAuthenticationException e) {
+        log.error("UnAuthenticationException occurred: {}", e.getMessage());
+        return ResponseDto.toExceptionResponseEntity(HttpStatus.UNAUTHORIZED, 4000);
+    }
 }

--- a/src/main/java/com/clean/cleanroom/exception/UnAuthenticationException.java
+++ b/src/main/java/com/clean/cleanroom/exception/UnAuthenticationException.java
@@ -4,7 +4,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 // 예외가 발생할 때 자동으로 401 Unauthorized 상태 반환
-
 public class UnAuthenticationException extends RuntimeException {
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/com/clean/cleanroom/redis/RedisService.java
+++ b/src/main/java/com/clean/cleanroom/redis/RedisService.java
@@ -12,12 +12,12 @@ import java.util.concurrent.TimeUnit;
 @Service
 @RequiredArgsConstructor
 public class RedisService {
+
     private final RedisTemplate<String, Object> redisTemplate;
 
     // 인증 코드 저장
     public void setCode(String email, String code) {
         ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
-        // 인증 코드를 5분(300초) 동안 저장
         valOperations.set(email, code, 300, TimeUnit.SECONDS);
     }
 
@@ -26,16 +26,31 @@ public class RedisService {
         ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
         Object code = valOperations.get(email);
         if (code == null) {
-            throw new CustomException(ErrorMsg.INVALID_VERIFICATION_CODE);
+            return null;  // 데이터가 없으면 null 반환
         }
         return code.toString();
+    }
+
+    // 객체 저장
+    public void setObject(String key, Object object, long timeout, TimeUnit timeUnit) {
+        ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
+        valOperations.set(key, object, timeout, timeUnit);
+    }
+
+    // 객체 조회
+    public <T> T getObject(String key, Class<T> clazz) {
+        ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
+        Object object = valOperations.get(key);
+        if (object == null) {
+            return null;  // 데이터가 없으면 null 반환
+        }
+        return clazz.cast(object);
     }
 
     // 인증 완료 플래그 설정
     public void setVerifiedFlag(String email) {
         ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
-        // 인증이 완료되면 인증 플래그를 Redis에 영구적으로 저장
-        valOperations.set(email + "_verified", "true", 10, TimeUnit.MINUTES); // 만료 시간을 원하면 설정 가능
+        valOperations.set(email + "_verified", "true", 10, TimeUnit.MINUTES);
     }
 
     // 인증 완료 여부 확인
@@ -43,5 +58,9 @@ public class RedisService {
         ValueOperations<String, Object> valOperations = redisTemplate.opsForValue();
         Object verifiedFlag = valOperations.get(email + "_verified");
         return verifiedFlag != null && verifiedFlag.equals("true");
+    }
+
+    public void deleteObject(String key) {
+        redisTemplate.delete(key);
     }
 }


### PR DESCRIPTION
## 🛠️ 작업 내용
- 내 청소의뢰 내역을 조회랑때 기존 로컬캐시에서 Redis를 사용하도록 변경하였습니다.
- 청소 의뢰 생성, 수정, 취소 등 데이터의 변경이 일어났을 때는
캐시를 무효화 하여 누락되는 데이터가 없도록 하였습니다.

<br/>

## ⚡️ Issue number & Link
- #95 

<br/>

## 📝 체크 리스트
- [x] 내 청소의뢰 내역 조회시 redis에 캐시를 저장하도록 적용
- [x] 청소 의뢰 생성, 수정, 취소 등 데이터의 변경이 일어나면 캐시를 무효화 시킴

<br/>
